### PR TITLE
0.3.17: Add ALLBUSRT market option and implement for ERCOT get_lmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ User group: https://groups.google.com/forum/#!forum/pyiso-users
 
 Changelog
 ---------
+* 0.3.17: Add ALLBUSRT market option and implement for ERCOT get_lmp; enables report that pulls LMPs for all ~12K electrical buses; also changed package install requirements to allow lxml>=3.6.1, which enables pyiso pip install on Python 3.6
 * 0.3.16: Implement ISONE get_morningreport and get_sevendayforecast
 * 0.3.15: Minor bugfixes to CAISO get_generation. 
 * 0.3.14: Minor bugfixes to ISONE, PJM, and ERCOT. 

--- a/pyiso/base.py
+++ b/pyiso/base.py
@@ -18,7 +18,7 @@ except ImportError:
     from urllib.request import urlopen  # Changed from urllib2 for python3.x
 
 # named tuple for time period interval labels
-IntervalChoices = namedtuple('IntervalChoices', ['hourly', 'fivemin', 'tenmin', 'fifteenmin', 'na', 'dam'])
+IntervalChoices = namedtuple('IntervalChoices', ['hourly', 'fivemin', 'tenmin', 'fifteenmin', 'na', 'dam', 'allbusrt'])
 
 # list of fuel choices
 FUEL_CHOICES = ['biogas', 'biomass', 'coal', 'geo', 'hydro',
@@ -32,8 +32,8 @@ class BaseClient(object):
     Base class for scraper/parser clients.
     """
     # choices for market and frequency interval labels
-    MARKET_CHOICES = IntervalChoices(hourly='RTHR', fivemin='RT5M', tenmin='RT5M', fifteenmin='RTPD', na='RT5M', dam='DAHR')
-    FREQUENCY_CHOICES = IntervalChoices(hourly='1hr', fivemin='5m', tenmin='10m', fifteenmin='15m', na='n/a', dam='1hr')
+    MARKET_CHOICES = IntervalChoices(hourly='RTHR', fivemin='RT5M', tenmin='RT5M', fifteenmin='RTPD', na='RT5M', dam='DAHR', allbusrt='ALLBUSRT')
+    FREQUENCY_CHOICES = IntervalChoices(hourly='1hr', fivemin='5m', tenmin='10m', fifteenmin='15m', na='n/a', dam='1hr', allbusrt='5m')
 
     # timezone
     TZ_NAME = 'UTC'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytz
 requests==2.9.1
 celery>=3.1
 xlrd
-lxml==3.6.1
+lxml>=3.6.1
 html5lib
 requests-cache
 mock

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'requests',
         'celery>=3.1',
         'xlrd',
-        'lxml==3.6.1',
+        'lxml>=3.6.1',
         'html5lib',
         'mock',
     ],

--- a/tests/test_ercot_allbusrt.py
+++ b/tests/test_ercot_allbusrt.py
@@ -1,0 +1,31 @@
+"""
+This script just does a flat pull on pyiso using ALLBUSRT.
+The ALLBUSRT market option will, for get_lmp, pull a separate report that 
+grabs the LMPs for all ~12K electrical buses, and not just the Settlment Points
+that are accessed via the RT5M market option.
+"""
+from datetime import datetime, timedelta
+import pandas as pd
+from pyiso import client_factory
+ercot = client_factory('ERCOT', timeout_seconds=60)
+
+#Use start and end time from now
+starts = datetime.now()-timedelta(minutes=6) #Note that one 5m interval will have LMPs for ~12K electrical buses
+ends = datetime.now()
+#make strings for end and start times
+startstr = starts.strftime("%Y-%m-%d %H:%M:%S")
+endstr = ends.strftime("%Y-%m-%d %H:%M:%S")
+
+
+#Get New Data via pyiso into dataframe
+print('I am getting the new data. This can take a while...')
+data = ercot.get_lmp(start_at=startstr, end_at=endstr, market="ALLBUSRT", node_id=None)
+new_data = pd.DataFrame(data)
+
+#correct time from UTC back to US Central (ERCOT time)
+new_data['timestamp'] = new_data['timestamp'].dt.tz_convert('US/Central')
+
+
+#now display the results
+print('I just got the new data.')
+print(new_data)


### PR DESCRIPTION
0.3.17: Add ALLBUSRT market option and implement for ERCOT get_lmp; enables report that pulls LMPs for all ~12K electrical buses; also changed package install requirements to allow lxml>=3.6.1, which enables pyiso pip install on Python 3.6