### PR TITLE
Changed base.py unzip() to prevent excessive logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,7 +55,3 @@ htmlcov
 
 # Certificate key files
 *.pem
-
-
-
-

--- a/pyiso/base.py
+++ b/pyiso/base.py
@@ -316,7 +316,8 @@ class BaseClient(object):
             # have zipfile
             z = zipfile.ZipFile(filecontent)
         except zipfile.BadZipfile:
-            LOGGER.error('%s: unzip failure for content:\n%s' % (self.NAME, content))
+            LOGGER.error('%s: unzip failure for content beginning:\n%s' % (self.NAME, str(content)[0:100]))
+            LOGGER.info('%s: Faulty unzip content:\n%s' % (self.NAME, content))
             return None
 
         # have unzipped content

--- a/pyiso/caiso.py
+++ b/pyiso/caiso.py
@@ -536,6 +536,7 @@ class CAISOClient(BaseClient):
 
         # read data from zip
         # This will be an array of content if successful, and None if unsuccessful
+
         content = self.unzip(response.content)
         if not content:
             return default_return_val


### PR DESCRIPTION
I noticed that when pulling data from CAISO, any issues with a corrupted zip file would result in the full ZIP file contents being dumped to my log file- resulting in a log file that was several hundred megabytes for my implementation! I've split the error reporting and content logging into two lines, with different logging levels- this allows errors to still be logged, but the full contents to be ignored if not desired.

Git seems to have picked up some minor changes to .gitignore and caiso.py; these should only be whitespace changes and can be ignored.