### PR TITLE
Dateutil v2.6 compatability

### DIFF
--- a/pyiso/base.py
+++ b/pyiso/base.py
@@ -200,7 +200,7 @@ class BaseClient(object):
         # parse
         try:
             local_ts = dateutil_parse(local_ts_str)
-        except AttributeError:  # already parsed
+        except (AttributeError, TypeError):  # already parsed
             local_ts = local_ts_str
 
         # localize


### PR DESCRIPTION
It appears that feeding a datetime object to the dateutil.parser no longer raises an AttributeError, but rather raises a TypeError in python-dateutil >v2.2.  This change should fix the version issue without affecting other functionalities.