### PR TITLE
#108 Upgraded lxml dependency from 3.6.1 to 3.6.4.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi
 freezegun
 html5lib
 libfaketime
-lxml==3.6.1
+lxml==3.6.4
 mock
 nose-timer
 nose==1.3.1

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'requests',
         'celery>=3.1',
         'xlrd',
-        'lxml==3.6.1',
+        'lxml==3.6.4',
         'html5lib',
         'mock',
         'certifi'


### PR DESCRIPTION
 I would like to upgrade further, but don't think it's prudent until we get
 unit tests and integration tests sorted in #130. Then we could probably
 bump the version up further.

 For now, I think upgrading the dependency from 3.6.1 to 3.6.4 is fairly
 safe (unit tests pass) and the version change bring in stabilization fixes
 only. See http://lxml.de/3.6/changes-3.6.4.html for details.