### PR TITLE
#130 Add usage of coverage plugin to nosetests call from Travis.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,11 +1,12 @@
 # .coveragerc to control coverage.py
 [run]
 source=
-    .
+    pyiso
 omit=
     */tests/*
     */tests.py
     *__init__.py
+    */venv/*
     *.virtualenvs*
     *script.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,6 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
-.coveragerc
 .tox
 nosetests.xml
 htmlcov/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ python:
 - '3.4'
 
 install:
-
-     # Install miniconda for python 2.7
+  # Install miniconda for python 2.7
   - wget https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
@@ -15,7 +14,6 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
 
-
   # Install
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - conda install -n test-environment pandas>=0.18 requests==2.9.1
@@ -23,7 +21,7 @@ install:
   - python setup.py install
   - pip install -r requirements.txt
   - pip install coveralls
-script: nosetests ./tests/unit/
+script: nosetests --with-coverage --cover-package=pyiso ./tests/unit/
 deploy:
   provider: pypi
   user: Anna.Schneider


### PR DESCRIPTION
I'm trying to fix the second continuous integration step, sending the unit test coverage report to coveralls. I'm opening this pull request early to trigger the continuous integration steps on pull requests and to see how my changes affect Travis and Coveralls.

Please do not merge to master until I request the merge in the comments of this pull request.