### PR TITLE
PEIClient adds support for latest get_load(...) and get_generation(...) values

### DIFF
--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -50,6 +50,7 @@ balancing authority abbrev.    balancing authority name/region          data sou
       NBP                       New Brunswick Power                      NBPower
       NEVP                      Nevada Power                             NVEnergy
       NYISO                     New York ISO                             NYISO
+      PEI                       Price Edward Island (Canada)             PEI
       PJM                       Mid-Atlantic                             PJM
       PNM                       Public Service Co New Mexico             SVERI
       SASK                      Saskatchewan Power                       SaskPower

--- a/docs/source/options.rst
+++ b/docs/source/options.rst
@@ -44,6 +44,10 @@ method                   ``latest``   ``start_at`` and ``end_at`` pair   ``yeste
 ``NYISO.get_load``        yes         yes                                no            yes
 ``NYISO.get_lmp``         yes         yes                                no            yes
 ``NYISO.get_trade``       yes         yes                                no            no
+``PEI.get_generation``    yes         no                                 no            no
+``PEI.get_load``          yes         no                                 no            no
+``PEI.get_trade``         no          no                                 no            no
+``PEI.get_lmp``           no          no                                 no            no
 ``PJM.get_generation``    yes         no                                 no            no
 ``PJM.get_load``          yes         yes                                no            yes
 ``PJM.get_trade``         yes         no                                 no            no

--- a/pyiso/__init__.py
+++ b/pyiso/__init__.py
@@ -36,6 +36,7 @@ BALANCING_AUTHORITIES = {
     'NBP': {'class': 'NBPowerClient', 'module': 'nbpower'},
     'NEVP': {'class': 'NVEnergyClient', 'module': 'nvenergy'},
     'NYISO': {'class': 'NYISOClient', 'module': 'nyiso'},
+    'PEI': {'class': 'PEIClient', 'module': 'pei'},
     'PJM': {'class': 'PJMClient', 'module': 'pjm'},
     'PNM': {'class': 'SVERIClient', 'module': 'sveri'},
     'SASK': {'class': 'SaskPowerClient', 'module': 'sask'},

--- a/pyiso/pei.py
+++ b/pyiso/pei.py
@@ -55,7 +55,7 @@ class PEIClient(BaseClient):
             sysload_list = json.loads(response.content.decode('utf-8'))
             sysload_json = sysload_list[0]
             seconds_epoch = int(sysload_json.get('updateDate', None))
-            last_updated = self.pei_tz.localize(datetime.fromtimestamp(seconds_epoch))
+            last_updated = datetime.fromtimestamp(timestamp=seconds_epoch, tz=self.pei_tz)
             total_on_island_load = float(sysload_json.get('data1', None))
             loads.append({
                 'ba_name': self.NAME,
@@ -80,7 +80,7 @@ class PEIClient(BaseClient):
             sysload_list = json.loads(response.content.decode('utf-8'))
             sysload_json = sysload_list[0]
             seconds_epoch = int(sysload_json.get('updateDate', None))
-            last_updated = self.pei_tz.localize(datetime.fromtimestamp(seconds_epoch))
+            last_updated = datetime.fromtimestamp(timestamp=seconds_epoch, tz=self.pei_tz)
             total_on_island_load = float(sysload_json.get('data1', None))
             wind_mw = float(sysload_json.get('data2', None))
             oil_mw = float(sysload_json.get('data3', None))

--- a/pyiso/pei.py
+++ b/pyiso/pei.py
@@ -1,0 +1,18 @@
+from pyiso.base import BaseClient
+
+
+class PEIClient(BaseClient):
+    NAME = 'PEI'
+    TZ_NAME = 'Canada/Atlantic'
+
+    def get_generation(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
+        pass
+
+    def get_load(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
+        pass
+
+    def get_trade(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
+        pass
+
+    def get_lmp(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
+        pass

--- a/pyiso/pei.py
+++ b/pyiso/pei.py
@@ -15,14 +15,19 @@ class PEIClient(BaseClient):
         self.chart_values_url = 'http://www.gov.pe.ca/windenergy/chart-values.php'
 
     def get_generation(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
-        pass
+        self.handle_options(latest=latest, yesterday=yesterday, start_at=start_at, end_at=end_at, **kwargs)
+        if latest:
+            return self.get_latest_generation()
+        else:
+            warnings.warn(message='PEIClient only supports the latest=True argument for retrieving generation mix.',
+                          category=UserWarning)
 
     def get_load(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
         self.handle_options(latest=latest, yesterday=yesterday, start_at=start_at, end_at=end_at, **kwargs)
         if latest:
             return self.get_latest_load()
         else:
-            warnings.warn(message='PEIPowerClient only supports the latest=True argument for retrieving load data.',
+            warnings.warn(message='PEIClient only supports the latest=True argument for retrieving load data.',
                           category=UserWarning)
 
     def get_trade(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
@@ -50,8 +55,44 @@ class PEIClient(BaseClient):
             loads.append({
                 'ba_name': self.NAME,
                 'timestamp': last_updated.astimezone(pytz.utc),
-                'freq': self.FREQUENCY_CHOICES.tenmin,  # Actually, it's been ~20 minutes pretty consistently.
+                'freq': self.FREQUENCY_CHOICES.tenmin,
                 'market': self.MARKET_CHOICES.tenmin,
                 'load_MW': total_on_island_load
+            })
+        return loads
+
+    def get_latest_generation(self):
+        """
+        Requests the JSON backing PEI's public "Wind Energy" page (http://www.gov.pe.ca/windenergy/chart.php)
+        and returns it in pyiso generation mix format.
+        :return: List of dicts, each with keys ``[ba_name, timestamp, freq, market, fuel_name, gen_MW]``.
+            Timestamps are in UTC.
+        :rtype: list
+        """
+        loads = []
+        response = self.request(self.chart_values_url)
+        if response:
+            sysload_list = json.loads(response.content.decode('utf-8'))
+            sysload_json = sysload_list[0]
+            seconds_epoch = int(sysload_json.get('updateDate', None))
+            last_updated = self.pei_tz.localize(datetime.fromtimestamp(seconds_epoch))
+            total_on_island_load = float(sysload_json.get('data1', None))
+            wind_mw = float(sysload_json.get('data2', None))
+            other_mw = total_on_island_load - wind_mw
+            loads.append({
+                'ba_name': self.NAME,
+                'timestamp': last_updated.astimezone(pytz.utc),
+                'freq': self.FREQUENCY_CHOICES.tenmin,
+                'market': self.MARKET_CHOICES.tenmin,
+                'fuel_name': 'wind',
+                'gen_MW': wind_mw
+            })
+            loads.append({
+                'ba_name': self.NAME,
+                'timestamp': last_updated.astimezone(pytz.utc),
+                'freq': self.FREQUENCY_CHOICES.tenmin,
+                'market': self.MARKET_CHOICES.tenmin,
+                'fuel_name': 'other',
+                'gen_MW': other_mw
             })
         return loads

--- a/pyiso/pei.py
+++ b/pyiso/pei.py
@@ -12,7 +12,7 @@ class PEIClient(BaseClient):
     """
 
     NAME = 'PEI'
-    TZ_NAME = 'Etc/GMT+4'  # Times are always given in Atlantic Standard Time
+    TZ_NAME = 'Etc/GMT-4'  # Times are always given in Atlantic Standard Time
 
     def __init__(self):
         super(PEIClient, self).__init__()

--- a/pyiso/pei.py
+++ b/pyiso/pei.py
@@ -6,6 +6,11 @@ from pyiso.base import BaseClient
 
 
 class PEIClient(BaseClient):
+    """
+    The government of Prince Edward Island, Canada publishes a "Wind Energy" summary page for the island at
+    http://www.gov.pe.ca/windenergy/chart.php The latest load and a basic generation mix can be derived from this data.
+    """
+
     NAME = 'PEI'
     TZ_NAME = 'Etc/GMT+4'  # Times are always given in Atlantic Standard Time
 

--- a/pyiso/pei.py
+++ b/pyiso/pei.py
@@ -1,18 +1,57 @@
+import json
+import warnings
+import pytz
+from datetime import datetime
 from pyiso.base import BaseClient
 
 
 class PEIClient(BaseClient):
     NAME = 'PEI'
-    TZ_NAME = 'Canada/Atlantic'
+    TZ_NAME = 'Etc/GMT+4'  # Times are always given in Atlantic Standard Time
+
+    def __init__(self):
+        super(PEIClient, self).__init__()
+        self.pei_tz = pytz.timezone(self.TZ_NAME)
+        self.chart_values_url = 'http://www.gov.pe.ca/windenergy/chart-values.php'
 
     def get_generation(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
         pass
 
     def get_load(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
-        pass
+        self.handle_options(latest=latest, yesterday=yesterday, start_at=start_at, end_at=end_at, **kwargs)
+        if latest:
+            return self.get_latest_load()
+        else:
+            warnings.warn(message='PEIPowerClient only supports the latest=True argument for retrieving load data.',
+                          category=UserWarning)
 
     def get_trade(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
         pass
 
     def get_lmp(self, latest=False, yesterday=False, start_at=False, end_at=False, **kwargs):
         pass
+
+    def get_latest_load(self):
+        """
+        Requests the JSON backing PEI's public "Wind Energy" page (http://www.gov.pe.ca/windenergy/chart.php)
+        and returns it in pyiso load format.
+        :return: List of dicts, each with keys ``[ba_name, timestamp, freq, market, load_MW]``.
+            Timestamps are in UTC.
+        :rtype: list
+        """
+        loads = []
+        response = self.request(self.chart_values_url)
+        if response:
+            sysload_list = json.loads(response.content.decode('utf-8'))
+            sysload_json = sysload_list[0]
+            seconds_epoch = int(sysload_json.get('updateDate', None))
+            last_updated = self.pei_tz.localize(datetime.fromtimestamp(seconds_epoch))
+            total_on_island_load = float(sysload_json.get('data1', None))
+            loads.append({
+                'ba_name': self.NAME,
+                'timestamp': last_updated.astimezone(pytz.utc),
+                'freq': self.FREQUENCY_CHOICES.tenmin,  # Actually, it's been ~20 minutes pretty consistently.
+                'market': self.MARKET_CHOICES.tenmin,
+                'load_MW': total_on_island_load
+            })
+        return loads

--- a/tests/fixtures/pei/chart-values.json
+++ b/tests/fixtures/pei/chart-values.json
@@ -1,0 +1,1 @@
+[{"data1":150.56,"data2":4.55,"data3":0,"data4":3.09,"data5":1.46,"updateDate":1506333661,"error":0}]

--- a/tests/integration/test_genmix.py
+++ b/tests/integration/test_genmix.py
@@ -65,7 +65,7 @@ class TestBaseGenMix(TestCase):
         # method not implemented yet
         self.assertRaises(NotImplementedError, c.get_generation)
 
-    def _run_null_repsonse_test(self, ba_name, **kwargs):
+    def _run_null_response_test(self, ba_name, **kwargs):
         # set up
         c = client_factory(ba_name)
 
@@ -104,7 +104,7 @@ class TestISONEGenMix(TestBaseGenMix):
 
 class TestMISOGenMix(TestBaseGenMix):
     def test_null_response_latest(self):
-        self._run_null_repsonse_test('MISO', latest=True)
+        self._run_null_response_test('MISO', latest=True)
 
     def test_latest(self):
         # basic test
@@ -200,7 +200,7 @@ class TestSPPGenMix(TestBaseGenMix):
 
 class TestBPAGenMix(TestBaseGenMix):
     def test_null_response_latest(self):
-        self._run_null_repsonse_test('BPA', latest=True)
+        self._run_null_response_test('BPA', latest=True)
 
     def test_latest(self):
         # basic test
@@ -238,7 +238,7 @@ class TestBPAGenMix(TestBaseGenMix):
 
 class TestCAISOGenMix(TestBaseGenMix):
     def test_null_response_latest(self):
-        self._run_null_repsonse_test('CAISO', latest=True)
+        self._run_null_response_test('CAISO', latest=True)
 
     def test_date_range_rthr(self):
         # basic test
@@ -348,7 +348,7 @@ class TestCAISOGenMix(TestBaseGenMix):
 
 class TestERCOTGenMix(TestBaseGenMix):
     def test_null_response_latest(self):
-        self._run_null_repsonse_test('ERCOT', latest=True)
+        self._run_null_response_test('ERCOT', latest=True)
 
     def test_latest(self):
         data = self._run_test('ERCOT', latest=True, market=self.MARKET_CHOICES.fivemin)
@@ -371,7 +371,7 @@ class TestERCOTGenMix(TestBaseGenMix):
 
 class TestPJMGenMix(TestBaseGenMix):
     def test_null_response_latest(self):
-        self._run_null_repsonse_test('PJM', latest=True)
+        self._run_null_response_test('PJM', latest=True)
 
     def test_latest(self):
         # basic test
@@ -396,7 +396,7 @@ class TestPJMGenMix(TestBaseGenMix):
 
 class TestNYISOGenMix(TestBaseGenMix):
     def test_null_response_latest(self):
-        self._run_null_repsonse_test('NYISO', latest=True)
+        self._run_null_response_test('NYISO', latest=True)
 
     def test_latest(self):
         # basic test
@@ -449,6 +449,19 @@ class TestNEVPGenMix(TestBaseGenMix):
         self._run_notimplemented_test('NEVP')
 
 
+class TestPEIGenMix(TestBaseGenMix):
+    def test_null_response_latest(self):
+        self._run_null_response_test('PEI', latest=True)
+
+    def test_latest(self):
+        # basic test
+        data = self._run_test('PEI', latest=True)
+
+        # test all timestamps are equal
+        timestamps = [d['timestamp'] for d in data]
+        self.assertEqual(len(set(timestamps)), 1)
+
+
 class TestSPPCGenMix(TestBaseGenMix):
     def test_failing(self):
         self._run_notimplemented_test('SPPC')
@@ -460,7 +473,7 @@ class TestSVERIGenMix(TestBaseGenMix):
         self.bas = [k for k, v in BALANCING_AUTHORITIES.items() if v['module'] == 'sveri']
 
     def test_null_response_latest(self):
-        self._run_null_repsonse_test(self.bas[0], latest=True)
+        self._run_null_response_test(self.bas[0], latest=True)
 
     # @freezegun.freeze_time('2016-05-20 12:10', tz_offset=0, tick=True)
     # @requests_mock.mock()

--- a/tests/integration/test_load.py
+++ b/tests/integration/test_load.py
@@ -369,6 +369,24 @@ class TestNYISOLoad(TestBaseLoad):
         self.assertLessEqual(min(timestamps), today+timedelta(days=2))
 
 
+class TestPEILoad(TestBaseLoad):
+    def test_null_response_latest(self):
+        self._run_null_repsonse_test('PEI', latest=True)
+
+    def test_latest(self):
+        # basic test
+        data = self._run_test('PEI', latest=True)
+
+        # test all timestamps are equal
+        timestamps = [d['timestamp'] for d in data]
+        self.assertEqual(len(set(timestamps)), 1)
+
+        # test flags
+        for dp in data:
+            self.assertEqual(dp['market'], self.MARKET_CHOICES.tenmin)
+            self.assertEqual(dp['freq'], self.FREQUENCY_CHOICES.tenmin)
+
+
 class TestPJMLoad(TestBaseLoad):
     def test_null_response_latest(self):
         self._run_null_repsonse_test('PJM', latest=True)

--- a/tests/unit/test_pei.py
+++ b/tests/unit/test_pei.py
@@ -27,7 +27,7 @@ class TestPEIClient(TestCase):
         self.assertIsInstance(self.c, BaseClient)
 
     @requests_mock.Mocker()
-    def test_get_load_parses_json(self, mock_request):
+    def test_get_load_success(self, mock_request):
         expected_response = read_fixture(self.c.NAME, 'chart-values.json').encode('utf8')
         mock_request.get('http://www.gov.pe.ca/windenergy/chart-values.php', content=expected_response)
 
@@ -37,3 +37,20 @@ class TestPEIClient(TestCase):
         self.assertEqual(load_ts[0].get('timestamp', None), datetime(year=2017, month=9, day=25, hour=10, minute=1,
                                                                      second=1, microsecond=0, tzinfo=pytz.utc))
         self.assertEqual(load_ts[0].get('load_MW', None), 150.56)
+
+    @requests_mock.Mocker()
+    def test_get_generation_success(self, mock_request):
+        expected_response = read_fixture(self.c.NAME, 'chart-values.json').encode('utf8')
+        mock_request.get('http://www.gov.pe.ca/windenergy/chart-values.php', content=expected_response)
+        expected_timestamp = datetime(year=2017, month=9, day=25, hour=10, minute=1, second=1, microsecond=0,
+                                      tzinfo=pytz.utc)
+
+        load_ts = self.c.get_generation(latest=True)
+
+        self.assertEqual(len(load_ts), 2)
+        self.assertEqual(load_ts[0].get('timestamp', None), expected_timestamp)
+        self.assertEqual(load_ts[0].get('fuel_name', None), 'wind')
+        self.assertEqual(load_ts[0].get('gen_MW', None), 4.55)
+        self.assertEqual(load_ts[1].get('timestamp', None), expected_timestamp)
+        self.assertEqual(load_ts[1].get('fuel_name', None), 'other')
+        self.assertEqual(load_ts[1].get('gen_MW', None), 146.01)

--- a/tests/unit/test_pei.py
+++ b/tests/unit/test_pei.py
@@ -1,6 +1,22 @@
+import os
+
+import pytz
+import requests_mock
+from datetime import datetime
 from unittest import TestCase
 from pyiso import client_factory
 from pyiso.base import BaseClient
+
+
+def read_fixture(ba_name, filename):
+    """
+    :param str ba_name: The balancing authority name.
+    :param str filename: The fixture file you wish to load.
+    :return: The file's content.
+    :rtype: str
+    """
+    fixtures_base_path = os.path.join(os.path.dirname(__file__), '../fixtures', ba_name.lower())
+    return open(os.path.join(fixtures_base_path, filename), 'r').read()
 
 
 class TestPEIClient(TestCase):
@@ -9,3 +25,15 @@ class TestPEIClient(TestCase):
 
     def test_pei_retrievable_from_client_factory(self):
         self.assertIsInstance(self.c, BaseClient)
+
+    @requests_mock.Mocker()
+    def test_get_load_parses_json(self, mock_request):
+        expected_response = read_fixture(self.c.NAME, 'chart-values.json').encode('utf8')
+        mock_request.get('http://www.gov.pe.ca/windenergy/chart-values.php', content=expected_response)
+
+        load_ts = self.c.get_load(latest=True)
+
+        self.assertEqual(len(load_ts), 1)
+        self.assertEqual(load_ts[0].get('timestamp', None), datetime(year=2017, month=9, day=25, hour=10, minute=1,
+                                                                     second=1, microsecond=0, tzinfo=pytz.utc))
+        self.assertEqual(load_ts[0].get('load_MW', None), 150.56)

--- a/tests/unit/test_pei.py
+++ b/tests/unit/test_pei.py
@@ -47,10 +47,13 @@ class TestPEIClient(TestCase):
 
         load_ts = self.c.get_generation(latest=True)
 
-        self.assertEqual(len(load_ts), 2)
+        self.assertEqual(len(load_ts), 3)
         self.assertEqual(load_ts[0].get('timestamp', None), expected_timestamp)
-        self.assertEqual(load_ts[0].get('fuel_name', None), 'wind')
-        self.assertEqual(load_ts[0].get('gen_MW', None), 4.55)
+        self.assertEqual(load_ts[0].get('fuel_name', None), 'oil')
+        self.assertEqual(load_ts[0].get('gen_MW', None), 0)
         self.assertEqual(load_ts[1].get('timestamp', None), expected_timestamp)
         self.assertEqual(load_ts[1].get('fuel_name', None), 'other')
         self.assertEqual(load_ts[1].get('gen_MW', None), 146.01)
+        self.assertEqual(load_ts[2].get('timestamp', None), expected_timestamp)
+        self.assertEqual(load_ts[2].get('fuel_name', None), 'wind')
+        self.assertEqual(load_ts[2].get('gen_MW', None), 4.55)

--- a/tests/unit/test_pei.py
+++ b/tests/unit/test_pei.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+from pyiso import client_factory
+from pyiso.base import BaseClient
+
+
+class TestPEIClient(TestCase):
+    def setUp(self):
+        self.c = client_factory('PEI')
+
+    def test_pei_retrievable_from_client_factory(self):
+        self.assertIsInstance(self.c, BaseClient)


### PR DESCRIPTION
The Prince Edward Island implementation uses data from this page: http://www.gov.pe.ca/windenergy/chart.php Only `latest=True` options are supported for `PEIClient` implementations of `get_load(...)` and `get_generation(...)` The derivation for this data is roughly as follows:

- `get_load(...)` is the "Total On-Island Load" value.
- `get_generation(...)` fuels are determined as follows:
    - `wind` is the "Total On-Island Wind Generated" value.
    - `oil` is the "Total On-Island Fossil Fueled Generation" value. The description for this fuel is, "the amount of electricity being generated from oil fired equipment. Typically, this generation is only required when there is an interruption of supply from off Island."
    - `other` is "Total On-Island Load" - wind - oil. In my understanding this is largely imported.

I originally felt that deriving `get_generation(...)` fuel mix from these charts was dubious (see #129. Looking at the PEI's data the "Wind Power Used On-Island" + "Wind Power Exported Off-Island" = "Total On-Island Wind Generated". The percentage value they give for "Total On-Island Wind Generated % of full load" is the percentage of "Total On-Island Load". So if the pyiso definition of "generation mix" is the mixture of fuels required used to supply the total load (i.e. internal load + exports + transmission losses) then I think my derivation of fuels for `get_generation(...)` is fine.
 
Closes #129.