### PR TITLE
reStructuredText markup fixes for Intro page in documentation

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,5 +1,5 @@
 Configuration
-==============
+=============
 
 
 Accounts
@@ -26,7 +26,7 @@ All other ISOs allow unauthenticated users to collect data, so no other credenti
 
 
 Logging and debug
-------------------
+-----------------
 
 By default, logging occurs at the INFO level. If you want to change this, you can set the `LOG_LEVEL` environment variable to the `integer associated with the desired log level <https://docs.python.org/2/library/logging.html#logging-levels>`_. For instance, ERROR is 40 and DEBUG is 10.
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -1,5 +1,5 @@
 Contributing
-=============
+============
 
 Right now, pyiso only has interfaces for collecting a small subset of the interesting electricity data that the ISOs provide.
 You can help by adding more!
@@ -8,7 +8,7 @@ if you have questions about any of this.
 
 
 For developers
----------------
+--------------
 
 When you're ready to get started coding:
 
@@ -23,7 +23,7 @@ When you're ready to get started coding:
 
 
 For data users
----------------
+--------------
 
 Found a bug, or know of a data source that you think pyiso should include?
 Please add an issue to `github <https://github.com/WattTime/pyiso/issues>`_.
@@ -59,7 +59,7 @@ Releasing via twine:
    twine upload dist/pyiso-VERSION.tar.gz
 
 Legal things
----------------
+------------
 
 Because we use pyiso as the base for our other software products, we ask that contributors sign the following Contributor License Agreement.  If you have any questions, or concerns, please drop us a line on Github.
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -30,39 +30,39 @@ Specifically, here are the included balancing authorities and their respective d
 
 Note: Some balancing authorities offer data directly and through the EIA client.
 
-============================= ======================================== ============
-balancing authority abbrev.    balancing authority name/region          data source
-============================= ======================================== ============
-      AESO                      Alberta Electricity System Operator      AESO
-      AZPS                      Arizona Public Service                   SVERI
-      BCH                       British Columbia Hydro                   BCH
-      BPA                       Bonneville Power Administration (Pac NW) BPA
-      CAISO                     California ISO                           CAISO
-      DEAA                      DECA Arlington Valley (AZ)               SVERI
-      ELE                       El Paso Electric                         SVERI
-      ERCOT                     Texas                                    ERCOT
-      EU                        European Union                           ENTSO
-      GRIF                      Griffith Energy (AZ)                     SVERI
-      HGMA                      Harquahala Generation Maricopa Arizona   SVERI
-      IESO                      Ontario                                  IESO
-      IID                       Imperial Irrigation District (CA)        SVERI
-      ISONE                     ISO New England                          ISONE
-      MISO                      Midcontinent ISO                         MISO
-      NBP                       New Brunswick Power                      NBPower
-      NLH                       Newfoundland and Labrador (Canada)       NLHydro
-      NSP                       Nova Scotia Power                        NSPower
-      NEVP                      Nevada Power                             NVEnergy
-      NYISO                     New York ISO                             NYISO
-      PEI                       Price Edward Island (Canada)             PEI
-      PJM                       Mid-Atlantic                             PJM
-      PNM                       Public Service Co New Mexico             SVERI
-      SASK                      Saskatchewan Power                       SaskPower
-      SPPC                      Sierra Pacific Power (NV)                NVEnergy
-      SRP                       Salt River Project (AZ)                  SVERI
-      TEPC                      Tuscon Electric Power Co                 SVERI
-      WALC                      WAPA Desert Southwest (NV, AZ)           SVERI
-      YUKON                     Yukon Energy (Canada)                    YUKON
-============================= ======================================== ============
+=========================== ======================================== ============
+balancing authority abbrev. balancing authority name/region          data source
+=========================== ======================================== ============
+AESO                        Alberta Elec. System Operator (Canada)   AESO
+AZPS                        Arizona Public Service                   SVERI
+BCH                         British Columbia Hydro (Canada)          BCH
+BPA                         Bonneville Power Administration (Pac NW) BPA
+CAISO                       California ISO                           CAISO
+DEAA                        DECA Arlington Valley (AZ)               SVERI
+ELE                         El Paso Electric                         SVERI
+ERCOT                       Texas                                    ERCOT
+EU                          European Union                           ENTSO
+GRIF                        Griffith Energy (AZ)                     SVERI
+HGMA                        Harquahala Generation Maricopa Arizona   SVERI
+IESO                        Ontario (Canada)                         IESO
+IID                         Imperial Irrigation District (CA)        SVERI
+ISONE                       ISO New England                          ISONE
+MISO                        Midcontinent ISO                         MISO
+NBP                         New Brunswick Power (Canada)             NBPower
+NLH                         Newfoundland and Labrador Hydro (Canada) NLHydro
+NSP                         Nova Scotia Power (Canada)               NSPower
+NEVP                        Nevada Power                             NVEnergy
+NYISO                       New York ISO                             NYISO
+PEI                         Price Edward Island (Canada)             PEI
+PJM                         Mid-Atlantic                             PJM
+PNM                         Public Service Co New Mexico             SVERI
+SASK                        Saskatchewan Power (Canada)              SaskPower
+SPPC                        Sierra Pacific Power (NV)                NVEnergy
+SRP                         Salt River Project (AZ)                  SVERI
+TEPC                        Tuscon Electric Power Co                 SVERI
+WALC                        WAPA Desert Southwest (NV, AZ)           SVERI
+YUKON                       Yukon Energy (Canada)                    YUKON
+=========================== ======================================== ============
 
 The following BAs are available through the EIA client.
 

--- a/docs/source/intro.rst
+++ b/docs/source/intro.rst
@@ -1,12 +1,12 @@
 Introduction
-=============
+============
 
 Pyiso provides Python client libraries for ISO and other power grid data sources.
 It powers the `WattTime Impact API <https://api.watttime.org/>`_,
 among other things.
 
 What's an ISO?
----------------
+--------------
 
 Electricity markets are operated by "balancing authorities,"
 which manage supply and demand for a given service area.
@@ -20,7 +20,7 @@ but choose to do so in a wide variety of unstandardized, inconvenient formats.
 Some smaller balancing authorities provide data too.
 
 What's included
-----------------
+---------------
 
 Pyiso makes it easier to collect data from ISOs and other balancing authorities
 by providing a uniform Python interface to each data stream.

--- a/docs/source/supporting.rst
+++ b/docs/source/supporting.rst
@@ -1,5 +1,5 @@
 Supporting
-===========
+==========
 
 Pyiso is an open source project maintained by `WattTime <http://WattTime.org>`_,
 a nonprofit that develops software standards to

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,5 +1,5 @@
 Usage
-======
+=====
 
 There are two main ways to use pyiso: via the client objects, or via celery tasks.
 The client approach is preferred for scripted data analysis.
@@ -7,7 +7,7 @@ The task approach enables asynchronous or periodic data collection
 and is in use at the `WattTime Impact API <http://api.watttime.org/>`_.
 
 Clients
---------
+-------
 
 .. py:currentmodule:: pyiso.base
 
@@ -57,7 +57,7 @@ Happy data analysis!
 
 
 Tasks
-------
+-----
 
 If you have a `celery <http://www.celeryproject.org/>`_ environment set up, you can use the tasks provided in the :py:mod:`pyiso.tasks` module.
 There is one task for each of the client's ``get_*`` methods that implements a thin wrapper around that method.


### PR DESCRIPTION
The table listing balancing authorities was not being rendered in GitHub or Read The Docs. This was due to the column header shorter than the length of BPA's description. It was being interpreted as row spanning multiple columns since the text was longer than the heading.

Fixes #170 and fixes #101.