### PR TITLE
Fixes read_excel(parse_cols=[...]) bug starting with pandas 0.21

### DIFF
--- a/tests/unit/test_bpa.py
+++ b/tests/unit/test_bpa.py
@@ -91,8 +91,7 @@ class TestBPABase(TestCase):
         # parse xls
         df = c.parse_to_df(xd, mode='xls', sheet_names=xd.sheet_names, skiprows=18,
                            index_col=0, parse_dates=True,
-                           parse_cols=[0, 2, 4, 5], header_names=['Wind', 'Hydro', 'Thermal']
-                           )
+                           usecols=[0, 2, 4, 5], header_names=['Wind', 'Hydro', 'Thermal'])
         self.assertEqual(list(df.columns), ['Wind', 'Hydro', 'Thermal'])
         self.assertGreater(len(df), 0)
         self.assertEqual(df.iloc[0].name, datetime(2014, 1, 1))


### PR DESCRIPTION
The continuous integration builds have been failing since c015878. This is no fault of our own, but panas 0.21 was released around that same time and the build server is using it.

The `parse_cols` argument was deprecated in 0.21 in favour of `usecols`.

https://pandas.pydata.org/pandas-docs/version/0.21/whatsnew.html#deprecations

Though it's supposed to be backward compatible, something is broken in the unit tests. This commit changes the kwarg that the unit test is using to `usecols`. Although `read_excel(...)` in pandas < 0.21 does not document the argument (e.g. http://pandas.pydata.org/pandas-docs/version/0.20/generated/pandas.read_excel.html vs. http://pandas.pydata.org/pandas-docs/version/0.21/generated/pandas.read_excel.html) the kwarg is used internally when `._parse_excel(...)` instantiates `TextParser` which calls `_handle_usecols(...)` internally. It all works; tested back to pandas 0.18 in Python 2.

We may want to bump requirements.txt and setup.py to pandas>=0.21 and use `usecols` elsewhere in pyiso if this turns up as a problem elsewhere.