### PR TITLE
Restrict pandas versions to pandas>=0.18,<0.21 for the time being.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ lxml==3.6.4
 mock
 nose-timer
 nose==1.3.1
-pandas>=0.18
+pandas>=0.18,<0.21
 parameterized
 python-dateutil==2.2
 pytz

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     test_suite='nose.collector',
     install_requires=[
         'beautifulsoup4==4.5.0',
-        'pandas>=0.18',
+        'pandas>=0.18,<0.21',
         'python-dateutil',
         'pytz',
         'requests',


### PR DESCRIPTION
The deprecation of read_excel(parse_cols=[]) in favour of read_excel(usecols=[]) affected the BPAClient and BaseClient negatively. This works around that version incompatibility until we're ready to upgrade and have a fix in place.

Fixes continuous integration server problems that started with c0158781885507941094bc744a52ee00aa70afff.