### PR TITLE
Version restrictions in requirements.txt and setup.py did not match. Now they do.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,6 @@ python-dateutil
 pytz
 requests-cache
 requests-mock
-requests==2.9.1
+requests
 Sphinx==1.2.2
 xlrd

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ nose-timer
 nose==1.3.1
 pandas>=0.18
 parameterized
-python-dateutil==2.2
+python-dateutil
 pytz
 requests-cache
 requests-mock


### PR DESCRIPTION
This aligns version numbers with `setup.py` since that's what actually gets used when building the `pyiso` library for PyPI. In the case of both edits, it also happens to be the least restrictive option for projects which are depending on `pyiso` through `pip`.