### PR TITLE
Loosen version restrictions of packages required for development

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-beautifulsoup4==4.5.0
+beautifulsoup4>=4.5.0
 celery>=3.1
 certifi
 freezegun

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ libfaketime
 lxml==3.6.4
 mock
 nose-timer
-nose==1.3.1
+nose
 pandas>=0.18,<0.21
 parameterized
 python-dateutil
@@ -15,5 +15,5 @@ pytz
 requests-cache
 requests-mock
 requests
-Sphinx==1.2.2
+Sphinx
 xlrd

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ certifi
 freezegun
 html5lib
 libfaketime
-lxml==3.6.4
+lxml>=3.6.4
 mock
 nose-timer
 nose

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
     ],
     test_suite='nose.collector',
     install_requires=[
-        'beautifulsoup4==4.5.0',
+        'beautifulsoup4>=4.5.0',
         'pandas>=0.18,<0.21',
         'python-dateutil',
         'pytz',

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
         'requests',
         'celery>=3.1',
         'xlrd',
-        'lxml==3.6.4',
+        'lxml>=3.6.4',
         'html5lib',
         'mock',
         'certifi'


### PR DESCRIPTION
Closes #163 by allowing more recent versions of `lxml`.

While working in `requirements.txt` and `setup.py` I decided to loosen the versions of required packages as much as possible, now that unit tests and continuous integration are in place once again thanks to #130.

All unit tests pass after these change with the latest compliant versions of packages in `requirements.txt` and I also ran all the integration tests. Though there were some failures (related to existing bugs) the integration tests looked as I'd expect.

From my perspective, this pull request is good to merge!